### PR TITLE
feat: translate interface to russian

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,7 @@ function App() {
             v7_relativeSplatPath: true
           }}
         >
-          <Suspense fallback={<Loading text="Loading page..." />}>
+          <Suspense fallback={<Loading text="Загрузка страницы..." />}>
             <Routes>
               {/* Public route for authentication */}
               <Route path="/auth" element={<AuthPage />} />
@@ -38,7 +38,7 @@ function App() {
               <Route path="/*" element={
                 <ProtectedRoute>
                   <Layout>
-                    <Suspense fallback={<Loading text="Loading content..." />}>
+                    <Suspense fallback={<Loading text="Загрузка контента..." />}>
                       <Routes>
                         <Route path="/" element={<Dashboard />} />
                         <Route path="/subscriptions" element={<Subscriptions />} />

--- a/src/components/AddSubscriptionModal.jsx
+++ b/src/components/AddSubscriptionModal.jsx
@@ -43,9 +43,9 @@ const AddSubscriptionModal = ({
 
   // Billing cycle options
   const billingCycleOptions = [
-    { value: 'weekly', label: 'Weekly' },
-    { value: 'monthly', label: 'Monthly' },
-    { value: 'yearly', label: 'Yearly' },
+    { value: 'weekly', label: 'Еженедельно' },
+    { value: 'monthly', label: 'Ежемесячно' },
+    { value: 'yearly', label: 'Ежегодно' },
   ];
 
   // Currency options
@@ -111,19 +111,19 @@ const AddSubscriptionModal = ({
     const newErrors = {};
 
     if (!formData.name.trim()) {
-      newErrors.name = 'Name is required';
+      newErrors.name = 'Требуется название';
     }
 
     if (!formData.amount || parseFloat(formData.amount) <= 0) {
-      newErrors.amount = 'Amount must be greater than 0';
+      newErrors.amount = 'Сумма должна быть больше 0';
     }
 
     if (!formData.nextPaymentDate) {
-      newErrors.nextPaymentDate = 'Next payment date is required';
+      newErrors.nextPaymentDate = 'Требуется дата следующего платежа';
     }
 
     if (formData.website && !isValidUrl(formData.website)) {
-      newErrors.website = 'Please enter a valid URL';
+      newErrors.website = 'Пожалуйста, введите корректный URL';
     }
 
     setErrors(newErrors);
@@ -134,7 +134,7 @@ const AddSubscriptionModal = ({
     try {
       new URL(string);
       return true;
-    } catch (_) {
+    } catch {
       return false;
     }
   };
@@ -181,14 +181,14 @@ const AddSubscriptionModal = ({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      title={isEditing ? 'Edit Subscription' : 'Add New Subscription'}
+      title={isEditing ? 'Редактировать подписку' : 'Добавить подписку'}
       size="md"
     >
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* Name */}
         <Input
-          label="Name"
-          placeholder="e.g., Netflix, Spotify"
+          label="Название"
+          placeholder="например, Netflix, Spotify"
           value={formData.name}
           onChange={handleInputChange('name')}
           error={errors.name}
@@ -197,8 +197,8 @@ const AddSubscriptionModal = ({
 
         {/* Description */}
         <Input
-          label="Description"
-          placeholder="Optional description"
+          label="Описание"
+          placeholder="Необязательное описание"
           value={formData.description}
           onChange={handleInputChange('description')}
           error={errors.description}
@@ -207,7 +207,7 @@ const AddSubscriptionModal = ({
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {/* Amount */}
           <Input
-            label="Amount"
+            label="Сумма"
             type="number"
             step="0.01"
             min="0"
@@ -220,7 +220,7 @@ const AddSubscriptionModal = ({
 
           {/* Currency */}
           <Select
-            label="Currency"
+            label="Валюта"
             value={formData.currency}
             onChange={handleInputChange('currency')}
             options={currencyOptions}
@@ -231,7 +231,7 @@ const AddSubscriptionModal = ({
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           {/* Billing Cycle */}
           <Select
-            label="Billing Cycle"
+            label="Цикл оплаты"
             value={formData.billingCycle}
             onChange={handleInputChange('billingCycle')}
             options={billingCycleOptions}
@@ -240,7 +240,7 @@ const AddSubscriptionModal = ({
 
           {/* Category */}
           <Select
-            label="Category"
+            label="Категория"
             value={formData.category}
             onChange={handleInputChange('category')}
             options={categoryOptions}
@@ -250,7 +250,7 @@ const AddSubscriptionModal = ({
 
         {/* Next Payment Date */}
         <Input
-          label="Next Payment Date"
+          label="Следующая дата платежа"
           type="date"
           value={formData.nextPaymentDate}
           onChange={handleInputChange('nextPaymentDate')}
@@ -260,7 +260,7 @@ const AddSubscriptionModal = ({
 
         {/* Website */}
         <Input
-          label="Website"
+          label="Веб-сайт"
           type="url"
           placeholder="https://example.com"
           value={formData.website}
@@ -278,7 +278,7 @@ const AddSubscriptionModal = ({
             className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-gray-300 rounded"
           />
           <label htmlFor="isActive" className="text-sm font-medium text-gray-700">
-            Active subscription
+            Активная подписка
           </label>
         </div>
 
@@ -290,15 +290,15 @@ const AddSubscriptionModal = ({
             onClick={onClose}
             disabled={isSubmitting}
           >
-            Cancel
+            Отмена
           </Button>
           <Button
             type="submit"
             disabled={isSubmitting}
           >
-            {isSubmitting 
-              ? (isEditing ? 'Updating...' : 'Adding...') 
-              : (isEditing ? 'Update Subscription' : 'Add Subscription')
+            {isSubmitting
+              ? (isEditing ? 'Обновление...' : 'Добавление...')
+              : (isEditing ? 'Обновить подписку' : 'Добавить подписку')
             }
           </Button>
         </div>

--- a/src/components/AuthForm.jsx
+++ b/src/components/AuthForm.jsx
@@ -25,7 +25,7 @@ const AuthForm = () => {
         if (error) throw error;
 
         if (data.user && !data.user.email_confirmed_at) {
-          setMessage('Check your email for the confirmation link!');
+          setMessage('Проверьте электронную почту для ссылки подтверждения!');
         }
       } else {
         const { error } = await supabase.auth.signInWithPassword({
@@ -88,7 +88,7 @@ const AuthForm = () => {
             Subscription Tracker
           </h1>
           <p className="text-gray-600">
-            {isSignUp ? 'Create your account' : 'Sign in to your account'}
+            {isSignUp ? 'Создайте аккаунт' : 'Войдите в свой аккаунт'}
           </p>
         </div>
 
@@ -106,7 +106,7 @@ const AuthForm = () => {
               <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
               <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
             </svg>
-            Continue with Google
+            Войти через Google
           </button>
 
           <button
@@ -118,7 +118,7 @@ const AuthForm = () => {
             <svg className="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
             </svg>
-            Continue with GitHub
+            Войти через GitHub
           </button>
         </div>
 
@@ -127,7 +127,7 @@ const AuthForm = () => {
             <div className="w-full border-t border-gray-300" />
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-white text-gray-500">Or continue with email</span>
+            <span className="px-2 bg-white text-gray-500">Или продолжите по электронной почте</span>
           </div>
         </div>
 
@@ -135,7 +135,7 @@ const AuthForm = () => {
         <form onSubmit={handleSubmit} className="space-y-6">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
-              Email address
+              Адрес электронной почты
             </label>
             <input
               id="email"
@@ -146,13 +146,13 @@ const AuthForm = () => {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-              placeholder="Enter your email address"
+              placeholder="Введите адрес электронной почты"
             />
           </div>
 
           <div>
             <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
-              Password
+              Пароль
             </label>
             <input
               id="password"
@@ -163,7 +163,7 @@ const AuthForm = () => {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
-              placeholder={isSignUp ? "Create a password" : "Enter your password"}
+              placeholder={isSignUp ? "Создайте пароль" : "Введите пароль"}
             />
           </div>
 
@@ -187,7 +187,7 @@ const AuthForm = () => {
             {isLoading ? (
               <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white"></div>
             ) : (
-              isSignUp ? 'Create Account' : 'Sign In'
+              isSignUp ? 'Создать аккаунт' : 'Войти'
             )}
           </button>
         </form>
@@ -198,7 +198,7 @@ const AuthForm = () => {
             onClick={() => setIsSignUp(!isSignUp)}
             className="text-sm text-purple-600 hover:text-purple-500 font-medium"
           >
-            {isSignUp ? 'Already have an account? Sign in' : "Don't have an account? Sign up"}
+            {isSignUp ? 'Уже есть аккаунт? Войти' : 'Нет аккаунта? Зарегистрироваться'}
           </button>
         </div>
       </div>

--- a/src/components/SubscriptionCard.jsx
+++ b/src/components/SubscriptionCard.jsx
@@ -37,7 +37,7 @@ const SubscriptionCard = ({
   };
 
   const handleDelete = () => {
-    if (window.confirm(`Are you sure you want to delete "${subscription.name}"?`)) {
+    if (window.confirm(`Вы уверены, что хотите удалить "${subscription.name}"?`)) {
       onDelete(subscription.id);
     }
   };
@@ -75,7 +75,7 @@ const SubscriptionCard = ({
                 size="sm"
                 onClick={handleWebsiteClick}
                 className="p-1"
-                title="Visit website"
+                title="Перейти на сайт"
               >
                 <ExternalLink className="h-4 w-4" />
               </Button>
@@ -85,7 +85,7 @@ const SubscriptionCard = ({
               size="sm"
               onClick={handleToggleActive}
               className="p-1"
-              title={subscription.isActive ? 'Deactivate' : 'Activate'}
+              title={subscription.isActive ? 'Деактивировать' : 'Активировать'}
             >
               {subscription.isActive ? (
                 <ToggleRight className="h-4 w-4 text-green-500" />
@@ -98,7 +98,7 @@ const SubscriptionCard = ({
               size="sm"
               onClick={handleEdit}
               className="p-1"
-              title="Edit subscription"
+              title="Редактировать подписку"
             >
               <Edit3 className="h-4 w-4" />
             </Button>
@@ -107,7 +107,7 @@ const SubscriptionCard = ({
               size="sm"
               onClick={handleDelete}
               className="p-1 text-red-600 hover:text-red-700 hover:bg-red-50"
-              title="Delete subscription"
+              title="Удалить подписку"
             >
               <Trash2 className="h-4 w-4" />
             </Button>
@@ -121,12 +121,12 @@ const SubscriptionCard = ({
               {formatCurrency(subscription.amount, subscription.currency)}
             </span>
             <span className="text-gray-500 text-sm">
-              per {subscription.billingCycle}
+              за {getBillingCycleLabel(subscription.billingCycle)}
             </span>
           </div>
           {subscription.billingCycle !== 'monthly' && (
             <p className="text-sm text-gray-500 mt-1">
-              ~{formatCurrency(monthlyAmount, subscription.currency)} monthly
+              ~{formatCurrency(monthlyAmount, subscription.currency)} в месяц
             </p>
           )}
         </div>
@@ -138,7 +138,7 @@ const SubscriptionCard = ({
               {getCategoryLabel(subscription.category)}
             </span>
             <span className={`text-xs px-2 py-1 rounded ${subscription.isActive ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
-              {subscription.isActive ? 'Active' : 'Inactive'}
+              {subscription.isActive ? 'Активна' : 'Неактивна'}
             </span>
           </div>
           
@@ -146,7 +146,7 @@ const SubscriptionCard = ({
             <div className="flex items-center space-x-2 text-sm text-gray-600">
               <Calendar className="h-4 w-4" />
               <span>
-                Next payment: {format(new Date(subscription.nextPaymentDate), 'MMM dd, yyyy')}
+                Следующий платеж: {format(new Date(subscription.nextPaymentDate), 'MMM dd, yyyy')}
               </span>
             </div>
           )}

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -10,7 +10,6 @@ import {
   User,
   LogOut
 } from 'lucide-react';
-import { shallow } from 'zustand/shallow';
 import { useShallow } from 'zustand/react/shallow';
 import { Button } from '@/components/ui';
 import { useUnifiedAuth } from '../auth/UnifiedAuthProvider.jsx';
@@ -50,7 +49,7 @@ const Header = () => {
       return user.email.split('@')[0];
     }
     
-    return 'User';
+    return 'Пользователь';
   };
   
   const displayName = getDisplayName();
@@ -82,10 +81,10 @@ const Header = () => {
   }, []);
 
   const navigation = [
-    { name: 'Dashboard', href: '/', icon: LayoutDashboard },
-    { name: 'Subscriptions', href: '/subscriptions', icon: CreditCard },
-    { name: 'Analytics', href: '/analytics', icon: BarChart3 },
-    { name: 'Settings', href: '/settings', icon: Settings },
+    { name: 'Главная', href: '/', icon: LayoutDashboard },
+    { name: 'Подписки', href: '/subscriptions', icon: CreditCard },
+    { name: 'Аналитика', href: '/analytics', icon: BarChart3 },
+    { name: 'Настройки', href: '/settings', icon: Settings },
   ];
 
   const isActive = (path) => {
@@ -148,7 +147,7 @@ const Header = () => {
         {/* User menu */}
         <div className="flex items-center space-x-4">
           <Button variant="outline" size="sm">
-            Export Data
+            Экспорт данных
           </Button>
           
           {/* User dropdown */}
@@ -184,7 +183,7 @@ const Header = () => {
                     className="w-full flex items-center space-x-2 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors"
                   >
                     <LogOut className="h-4 w-4" />
-                    <span>{loading ? 'Signing out...' : 'Sign out'}</span>
+                    <span>{loading ? 'Выход...' : 'Выйти'}</span>
                   </button>
                 </div>
               </div>

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { shallow } from 'zustand/shallow';
 import { useShallow } from 'zustand/react/shallow';
 import useUnifiedStore from '@/store/unified-store';
 import Header from './Header.jsx';

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -13,10 +13,10 @@ const Sidebar = ({ isOpen, onClose }) => {
   const location = useLocation();
 
   const navigation = [
-    { name: 'Dashboard', href: '/', icon: LayoutDashboard },
-    { name: 'Subscriptions', href: '/subscriptions', icon: CreditCard },
-    { name: 'Analytics', href: '/analytics', icon: BarChart3 },
-    { name: 'Settings', href: '/settings', icon: Settings },
+    { name: 'Главная', href: '/', icon: LayoutDashboard },
+    { name: 'Подписки', href: '/subscriptions', icon: CreditCard },
+    { name: 'Аналитика', href: '/analytics', icon: BarChart3 },
+    { name: 'Настройки', href: '/settings', icon: Settings },
   ];
 
   const isActive = (path) => {

--- a/src/components/ui/Loading.jsx
+++ b/src/components/ui/Loading.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Loading = ({ size = 'md', text = 'Loading...', className = '' }) => {
+const Loading = ({ size = 'md', text = 'Загрузка...', className = '' }) => {
   const sizes = {
     sm: 'h-4 w-4',
     md: 'h-6 w-6',

--- a/src/components/ui/Select.jsx
+++ b/src/components/ui/Select.jsx
@@ -7,7 +7,7 @@ const Select = ({
   value,
   onChange,
   options = [],
-  placeholder = 'Select an option',
+  placeholder = 'Выберите вариант',
   disabled = false,
   required = false,
   className = '',

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -18,14 +18,13 @@ import {
   Tooltip, 
   ResponsiveContainer 
 } from 'recharts';
-import { shallow } from 'zustand/shallow';
 import { useShallow } from 'zustand/react/shallow';
 import useUnifiedStore from '@/store/unified-store';
 import { Card } from '@/components/ui';
-import { 
-  formatCurrency, 
-  getCategoryLabel, 
-  getCategoryColor 
+import {
+  formatCurrency,
+  getCategoryLabel,
+  getCategoryColor
 } from '@/types';
 
 const Analytics = () => {
@@ -81,8 +80,8 @@ const Analytics = () => {
     if (totalMonthly > 100) {
       insights.push({
         type: 'warning',
-        title: 'High Monthly Spending',
-        description: `You're spending ${formatCurrency(totalMonthly)} monthly. Consider reviewing your subscriptions.`,
+        title: 'Высокие месячные расходы',
+        description: `Вы тратите ${formatCurrency(totalMonthly)} в месяц. Рассмотрите возможность пересмотра подписок.`,
         icon: TrendingUp,
         color: 'text-orange-600 bg-orange-50'
       });
@@ -94,8 +93,8 @@ const Analytics = () => {
     if (highestCategory && highestCategory.percentage > 40) {
       insights.push({
         type: 'info',
-        title: 'Category Dominance',
-        description: `${getCategoryLabel(highestCategory.category)} accounts for ${highestCategory.percentage.toFixed(1)}% of your spending.`,
+        title: 'Доминирование категории',
+        description: `${getCategoryLabel(highestCategory.category)} составляет ${highestCategory.percentage.toFixed(1)}% ваших расходов.`,
         icon: PieChart,
         color: 'text-blue-600 bg-blue-50'
       });
@@ -104,8 +103,8 @@ const Analytics = () => {
     if (upcomingPayments.length > 3) {
       insights.push({
         type: 'info',
-        title: 'Multiple Upcoming Payments',
-        description: `You have ${upcomingPayments.length} payments due in the next 30 days.`,
+        title: 'Несколько предстоящих платежей',
+        description: `У вас ${upcomingPayments.length} платежей в ближайшие 30 дней.`,
         icon: Calendar,
         color: 'text-purple-600 bg-purple-50'
       });
@@ -143,9 +142,9 @@ const Analytics = () => {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold text-gray-900">Analytics</h1>
+        <h1 className="text-3xl font-bold text-gray-900">Аналитика</h1>
         <p className="text-gray-600 mt-1">
-          Insights into your subscription spending
+          Аналитика ваших расходов на подписки
         </p>
       </div>
 
@@ -157,12 +156,12 @@ const Analytics = () => {
               <DollarSign className="h-6 w-6 text-green-600" />
             </div>
             <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Monthly Total</p>
+              <p className="text-sm font-medium text-gray-600">Ежемесячно</p>
               <p className="text-2xl font-semibold text-gray-900">
                 {formatCurrency(totalMonthly)}
               </p>
               <p className="text-sm text-gray-500">
-                {formatCurrency(totalYearly)} yearly
+                {formatCurrency(totalYearly)} в год
               </p>
             </div>
           </div>
@@ -174,12 +173,12 @@ const Analytics = () => {
               <TrendingUp className="h-6 w-6 text-blue-600" />
             </div>
             <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Average per Service</p>
+              <p className="text-sm font-medium text-gray-600">Средняя стоимость услуги</p>
               <p className="text-2xl font-semibold text-gray-900">
                 {formatCurrency(averagePerSubscription)}
               </p>
               <p className="text-sm text-gray-500">
-                {activeSubscriptions.length} active services
+                {activeSubscriptions.length} активных сервисов
               </p>
             </div>
           </div>
@@ -191,12 +190,12 @@ const Analytics = () => {
               <Calendar className="h-6 w-6 text-purple-600" />
             </div>
             <div className="ml-4">
-              <p className="text-sm font-medium text-gray-600">Next 30 Days</p>
+              <p className="text-sm font-medium text-gray-600">Следующие 30 дней</p>
               <p className="text-2xl font-semibold text-gray-900">
                 {upcomingPayments.length}
               </p>
               <p className="text-sm text-gray-500">
-                payments due
+                предстоящих платежей
               </p>
             </div>
           </div>
@@ -208,7 +207,7 @@ const Analytics = () => {
         {/* Spending by Category */}
         <Card className="p-6">
           <Card.Header>
-            <Card.Title>Spending by Category</Card.Title>
+            <Card.Title>Расходы по категориям</Card.Title>
           </Card.Header>
           <Card.Content>
             {categorySpending.length > 0 ? (
@@ -265,7 +264,7 @@ const Analytics = () => {
             ) : (
               <div className="text-center py-8 text-gray-500">
                 <PieChart className="h-12 w-12 mx-auto mb-3 text-gray-300" />
-                <p>No spending data available</p>
+                <p>Данные о расходах недоступны</p>
               </div>
             )}
           </Card.Content>
@@ -274,7 +273,7 @@ const Analytics = () => {
         {/* Monthly Trend */}
         <Card className="p-6">
           <Card.Header>
-            <Card.Title>Monthly Spending Trend</Card.Title>
+            <Card.Title>Тренд месячных расходов</Card.Title>
           </Card.Header>
           <Card.Content>
             <div className="h-64">
@@ -296,7 +295,7 @@ const Analytics = () => {
       {insights.length > 0 && (
         <Card className="p-6">
           <Card.Header>
-            <Card.Title>Spending Insights</Card.Title>
+            <Card.Title>Анализ расходов</Card.Title>
           </Card.Header>
           <Card.Content>
             <div className="space-y-4">
@@ -323,7 +322,7 @@ const Analytics = () => {
       {upcomingPayments.length > 0 && (
         <Card className="p-6">
           <Card.Header>
-            <Card.Title>Upcoming Payments (Next 30 Days)</Card.Title>
+            <Card.Title>Ближайшие платежи (30 дней)</Card.Title>
           </Card.Header>
           <Card.Content>
             <div className="space-y-3">
@@ -336,7 +335,7 @@ const Analytics = () => {
                         {payment.subscriptionName}
                       </p>
                       <p className="text-sm text-gray-500">
-                        Due: {new Date(payment.dueDate).toLocaleDateString()}
+                        К оплате: {new Date(payment.dueDate).toLocaleDateString()}
                       </p>
                     </div>
                   </div>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -10,11 +10,10 @@ import {
   AlertCircle
 } from 'lucide-react';
 import { format } from 'date-fns';
-import { shallow } from 'zustand/shallow';
 import { useShallow } from 'zustand/react/shallow';
 import useUnifiedStore from '@/store/unified-store';
 import { Card, Button } from '@/components/ui';
-import { formatCurrency, getCategoryColor, getCategoryLabel } from '@/types';
+import { formatCurrency, getCategoryColor, getCategoryLabel, getBillingCycleLabel } from '@/types';
 
 const Dashboard = () => {
   // Optimized unified store selectors with shallow comparison
@@ -42,25 +41,25 @@ const Dashboard = () => {
 
   const stats = [
     {
-      name: 'Monthly Spending',
+      name: 'Месячные расходы',
       value: formatCurrency(totalMonthly),
       icon: DollarSign,
       color: 'text-green-600 bg-green-50',
     },
     {
-      name: 'Yearly Spending',
+      name: 'Годовые расходы',
       value: formatCurrency(totalYearly),
       icon: TrendingUp,
       color: 'text-blue-600 bg-blue-50',
     },
     {
-      name: 'Active Subscriptions',
+      name: 'Активные подписки',
       value: activeSubscriptions.length.toString(),
       icon: CreditCard,
       color: 'text-purple-600 bg-purple-50',
     },
     {
-      name: 'Payments This Month',
+      name: 'Платежи в этом месяце',
       value: thisMonthPayments.length.toString(),
       icon: Calendar,
       color: 'text-orange-600 bg-orange-50',
@@ -72,15 +71,15 @@ const Dashboard = () => {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
+          <h1 className="text-3xl font-bold text-gray-900">Главная</h1>
           <p className="text-gray-600 mt-1">
-            Track your subscriptions and spending
+            Отслеживайте свои подписки и расходы
           </p>
         </div>
         <Link to="/subscriptions">
           <Button className="flex items-center space-x-2">
             <Plus className="h-4 w-4" />
-            <span>Add Subscription</span>
+            <span>Добавить подписку</span>
           </Button>
         </Link>
       </div>
@@ -116,13 +115,13 @@ const Dashboard = () => {
             <div className="flex items-center justify-between">
               <Card.Title className="flex items-center space-x-2">
                 <Clock className="h-5 w-5 text-orange-500" />
-                <span>Upcoming Payments</span>
+                <span>Ближайшие платежи</span>
               </Card.Title>
               <Link 
                 to="/subscriptions" 
                 className="text-sm text-primary-600 hover:text-primary-700"
               >
-                View all
+                Смотреть все
               </Link>
             </div>
           </Card.Header>
@@ -156,7 +155,7 @@ const Dashboard = () => {
             ) : (
               <div className="text-center py-8 text-gray-500">
                 <Calendar className="h-12 w-12 mx-auto mb-3 text-gray-300" />
-                <p>No upcoming payments in the next week</p>
+                <p>Нет платежей на ближайшую неделю</p>
               </div>
             )}
           </Card.Content>
@@ -168,13 +167,13 @@ const Dashboard = () => {
             <div className="flex items-center justify-between">
               <Card.Title className="flex items-center space-x-2">
                 <CreditCard className="h-5 w-5 text-blue-500" />
-                <span>Recent Subscriptions</span>
+                <span>Недавние подписки</span>
               </Card.Title>
               <Link 
                 to="/subscriptions" 
                 className="text-sm text-primary-600 hover:text-primary-700"
               >
-                Manage all
+                Управлять всеми
               </Link>
             </div>
           </Card.Header>
@@ -202,7 +201,7 @@ const Dashboard = () => {
                           {formatCurrency(subscription.amount, subscription.currency)}
                         </p>
                         <p className="text-sm text-gray-500">
-                          per {subscription.billingCycle}
+                          за {getBillingCycleLabel(subscription.billingCycle)}
                         </p>
                       </div>
                     </div>
@@ -211,9 +210,9 @@ const Dashboard = () => {
             ) : (
               <div className="text-center py-8 text-gray-500">
                 <CreditCard className="h-12 w-12 mx-auto mb-3 text-gray-300" />
-                <p className="mb-3">No subscriptions yet</p>
+                <p className="mb-3">Подписок пока нет</p>
                 <Link to="/subscriptions">
-                  <Button size="sm">Add your first subscription</Button>
+                  <Button size="sm">Добавить первую подписку</Button>
                 </Link>
               </div>
             )}
@@ -228,16 +227,16 @@ const Dashboard = () => {
             <AlertCircle className="h-5 w-5 text-amber-500 mt-0.5" />
             <div>
               <h3 className="font-medium text-amber-800">
-                High Monthly Spending Detected
+                Обнаружены высокие месячные расходы
               </h3>
               <p className="text-amber-700 mt-1">
-                You're spending {formatCurrency(totalMonthly)} monthly on subscriptions. 
-                Consider reviewing your subscriptions to optimize costs.
+                Вы тратите {formatCurrency(totalMonthly)} в месяц на подписки.
+                Рассмотрите возможность пересмотреть подписки для оптимизации расходов.
               </p>
               <div className="mt-3">
                 <Link to="/analytics">
                   <Button variant="outline" size="sm" className="bg-white border-amber-300 text-amber-700 hover:bg-amber-100">
-                    View Analytics
+                    Смотреть аналитику
                   </Button>
                 </Link>
               </div>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -28,7 +28,7 @@ const Settings = () => {
   };
 
   const handleClearAllData = () => {
-    if (window.confirm('Are you sure you want to delete all subscription data? This action cannot be undone.')) {
+    if (window.confirm('Вы уверены, что хотите удалить все данные о подписках? Это действие нельзя отменить.')) {
       localStorage.removeItem('subscription-tracker-storage');
       window.location.reload();
     }
@@ -38,9 +38,9 @@ const Settings = () => {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold text-gray-900">Settings</h1>
+        <h1 className="text-3xl font-bold text-gray-900">Настройки</h1>
         <p className="text-gray-600 mt-1">
-          Manage your application preferences and data
+          Управляйте настройками приложения и данными
         </p>
       </div>
 
@@ -49,16 +49,16 @@ const Settings = () => {
         <Card.Header>
           <Card.Title className="flex items-center space-x-2">
             <SettingsIcon className="h-5 w-5" />
-            <span>Data Management</span>
+            <span>Управление данными</span>
           </Card.Title>
         </Card.Header>
         <Card.Content>
           <div className="space-y-4">
             <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
               <div>
-                <h3 className="font-medium text-gray-900">Export Data</h3>
+                <h3 className="font-medium text-gray-900">Экспорт данных</h3>
                 <p className="text-sm text-gray-600">
-                  Download all your subscription data as a JSON file
+                  Скачайте все данные о подписках в файле JSON
                 </p>
               </div>
               <Button
@@ -67,15 +67,15 @@ const Settings = () => {
                 className="flex items-center space-x-2"
               >
                 <Download className="h-4 w-4" />
-                <span>Export</span>
+                <span>Экспорт</span>
               </Button>
             </div>
 
             <div className="flex items-center justify-between p-4 bg-red-50 rounded-lg border border-red-200">
               <div>
-                <h3 className="font-medium text-red-900">Clear All Data</h3>
+                <h3 className="font-medium text-red-900">Удалить все данные</h3>
                 <p className="text-sm text-red-700">
-                  Permanently delete all subscriptions and settings
+                  Безвозвратно удалить все подписки и настройки
                 </p>
               </div>
               <Button
@@ -84,7 +84,7 @@ const Settings = () => {
                 className="flex items-center space-x-2"
               >
                 <Trash2 className="h-4 w-4" />
-                <span>Clear Data</span>
+                <span>Удалить данные</span>
               </Button>
             </div>
           </div>
@@ -96,28 +96,28 @@ const Settings = () => {
         <Card.Header>
           <Card.Title className="flex items-center space-x-2">
             <Info className="h-5 w-5" />
-            <span>Application Information</span>
+            <span>Информация о приложении</span>
           </Card.Title>
         </Card.Header>
         <Card.Content>
           <div className="space-y-3">
             <div className="flex justify-between">
-              <span className="text-gray-600">Version:</span>
+              <span className="text-gray-600">Версия:</span>
               <span className="font-medium">1.0.0</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-gray-600">Total Subscriptions:</span>
+              <span className="text-gray-600">Всего подписок:</span>
               <span className="font-medium">{subscriptions.length}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-gray-600">Active Subscriptions:</span>
+              <span className="text-gray-600">Активных подписок:</span>
               <span className="font-medium">
                 {subscriptions.filter(sub => sub.isActive).length}
               </span>
             </div>
             <div className="flex justify-between">
-              <span className="text-gray-600">Data Storage:</span>
-              <span className="font-medium">Local Browser Storage</span>
+              <span className="text-gray-600">Хранилище данных:</span>
+              <span className="font-medium">Локальное хранилище браузера</span>
             </div>
           </div>
         </Card.Content>
@@ -126,21 +126,21 @@ const Settings = () => {
       {/* Help & Support */}
       <Card className="p-6">
         <Card.Header>
-          <Card.Title>Help & Support</Card.Title>
+          <Card.Title>Помощь и поддержка</Card.Title>
         </Card.Header>
         <Card.Content>
           <div className="space-y-3 text-sm text-gray-600">
             <p>
-              <strong>Getting Started:</strong> Add your first subscription by clicking the "Add Subscription" button.
+              <strong>Начало работы:</strong> Добавьте первую подписку, нажав кнопку «Добавить подписку».
             </p>
             <p>
-              <strong>Categories:</strong> Organize subscriptions into categories like Entertainment, Software, Utilities, etc.
+              <strong>Категории:</strong> Организуйте подписки по категориям, таким как Развлечения, Программное обеспечение, Коммунальные услуги и т.д.
             </p>
             <p>
-              <strong>Analytics:</strong> View spending insights and track your subscription costs over time.
+              <strong>Аналитика:</strong> Просматривайте аналитику расходов и отслеживайте стоимость подписок во времени.
             </p>
             <p>
-              <strong>Data Privacy:</strong> All data is stored locally in your browser. No information is sent to external servers.
+              <strong>Конфиденциальность данных:</strong> Все данные хранятся локально в вашем браузере. Никакая информация не отправляется на внешние серверы.
             </p>
           </div>
         </Card.Content>

--- a/src/pages/Subscriptions.jsx
+++ b/src/pages/Subscriptions.jsx
@@ -8,7 +8,6 @@ import {
   SortAsc,
   SortDesc 
 } from 'lucide-react';
-import { shallow } from 'zustand/shallow';
 import { useShallow } from 'zustand/react/shallow';
 import useUnifiedStore from '@/store/unified-store';
 import { Button, Input, Select, Card } from '@/components/ui';
@@ -56,7 +55,7 @@ const Subscriptions = () => {
 
   // Filter options
   const categoryOptions = [
-    { value: 'all', label: 'All Categories' },
+    { value: 'all', label: 'Все категории' },
     { value: 'entertainment', label: getCategoryLabel('entertainment') },
     { value: 'utilities', label: getCategoryLabel('utilities') },
     { value: 'software', label: getCategoryLabel('software') },
@@ -66,16 +65,16 @@ const Subscriptions = () => {
   ];
 
   const statusOptions = [
-    { value: 'all', label: 'All Status' },
-    { value: 'active', label: 'Active' },
-    { value: 'inactive', label: 'Inactive' },
+    { value: 'all', label: 'Любой статус' },
+    { value: 'active', label: 'Активна' },
+    { value: 'inactive', label: 'Неактивна' },
   ];
 
   const sortOptions = [
-    { value: 'name', label: 'Name' },
-    { value: 'amount', label: 'Amount' },
-    { value: 'nextPayment', label: 'Next Payment' },
-    { value: 'createdAt', label: 'Date Added' },
+    { value: 'name', label: 'Название' },
+    { value: 'amount', label: 'Сумма' },
+    { value: 'nextPayment', label: 'Следующий платеж' },
+    { value: 'createdAt', label: 'Дата добавления' },
   ];
 
   // Filter subscriptions by search term
@@ -121,9 +120,9 @@ const Subscriptions = () => {
       {/* Header */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between space-y-4 sm:space-y-0">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Subscriptions</h1>
+          <h1 className="text-3xl font-bold text-gray-900">Подписки</h1>
           <p className="text-gray-600 mt-1">
-            Manage your recurring subscriptions
+            Управляйте своими регулярными подписками
           </p>
         </div>
         <Button 
@@ -131,7 +130,7 @@ const Subscriptions = () => {
           className="flex items-center space-x-2"
         >
           <Plus className="h-4 w-4" />
-          <span>Add Subscription</span>
+          <span>Добавить подписку</span>
         </Button>
       </div>
 
@@ -144,7 +143,7 @@ const Subscriptions = () => {
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
               <input
                 type="text"
-                placeholder="Search subscriptions..."
+                placeholder="Поиск подписок..."
                 className="pl-10 input-field"
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
@@ -181,7 +180,7 @@ const Subscriptions = () => {
                 size="sm"
                 onClick={handleSortOrderToggle}
                 className="px-2"
-                title={`Sort ${filters.sortOrder === 'asc' ? 'Ascending' : 'Descending'}`}
+                title={`Сортировка: ${filters.sortOrder === 'asc' ? 'по возрастанию' : 'по убыванию'}`}
               >
                 {filters.sortOrder === 'asc' ? (
                   <SortAsc className="h-4 w-4" />
@@ -217,7 +216,7 @@ const Subscriptions = () => {
       {/* Results Stats */}
       <div className="flex items-center justify-between text-sm text-gray-600">
         <span>
-          Showing {searchFilteredSubscriptions.length} of {filteredSubscriptions.length} subscriptions
+          Показано {searchFilteredSubscriptions.length} из {filteredSubscriptions.length} подписок
         </span>
         {(searchTerm || filters.category !== 'all' || filters.status !== 'all') && (
           <Button
@@ -233,7 +232,7 @@ const Subscriptions = () => {
               });
             }}
           >
-            Clear filters
+            Сбросить фильтры
           </Button>
         )}
       </div>
@@ -261,16 +260,16 @@ const Subscriptions = () => {
             {searchTerm || filters.category !== 'all' || filters.status !== 'all' ? (
               <>
                 <Filter className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-                <h3 className="text-lg font-medium mb-2">No subscriptions found</h3>
-                <p>Try adjusting your search or filters</p>
+                <h3 className="text-lg font-medium mb-2">Подписки не найдены</h3>
+                <p>Попробуйте изменить поиск или фильтры</p>
               </>
             ) : (
               <>
                 <Plus className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-                <h3 className="text-lg font-medium mb-2">No subscriptions yet</h3>
-                <p className="mb-4">Start tracking your recurring expenses</p>
+                <h3 className="text-lg font-medium mb-2">Подписок пока нет</h3>
+                <p className="mb-4">Начните отслеживать свои регулярные расходы</p>
                 <Button onClick={handleAddSubscription}>
-                  Add your first subscription
+                  Добавить первую подписку
                 </Button>
               </>
             )}

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -32,21 +32,21 @@ export const getCategoryColor = (category) => {
 
 export const getCategoryLabel = (category) => {
   const labels = {
-    entertainment: 'Entertainment',
-    utilities: 'Utilities',
-    software: 'Software',
-    food: 'Food & Delivery',
-    health: 'Health & Fitness',
-    other: 'Other',
+    entertainment: 'Развлечения',
+    utilities: 'Коммунальные услуги',
+    software: 'Программное обеспечение',
+    food: 'Еда и доставка',
+    health: 'Здоровье и фитнес',
+    other: 'Другое',
   };
-  return labels[category] || 'Other';
+  return labels[category] || 'Другое';
 };
 
 export const getBillingCycleLabel = (cycle) => {
   const labels = {
-    weekly: 'Weekly',
-    monthly: 'Monthly',
-    yearly: 'Yearly',
+    weekly: 'Еженедельно',
+    monthly: 'Ежемесячно',
+    yearly: 'Ежегодно',
   };
   return labels[cycle];
 };
@@ -83,7 +83,7 @@ export const calculateNextPaymentDate = (lastPayment, cycle) => {
 };
 
 export const formatCurrency = (amount, currency = 'USD') => {
-  return new Intl.NumberFormat('en-US', {
+  return new Intl.NumberFormat('ru-RU', {
     style: 'currency',
     currency,
   }).format(amount);
@@ -98,23 +98,23 @@ export const validateSubscription = (subscription) => {
   const errors = {};
   
   if (!subscription.name || subscription.name.trim() === '') {
-    errors.name = 'Name is required';
+    errors.name = 'Требуется название';
   }
-  
+
   if (!subscription.amount || subscription.amount <= 0) {
-    errors.amount = 'Amount must be greater than 0';
+    errors.amount = 'Сумма должна быть больше 0';
   }
-  
+
   if (!subscription.billingCycle || !Object.values(BILLING_CYCLES).includes(subscription.billingCycle)) {
-    errors.billingCycle = 'Valid billing cycle is required';
+    errors.billingCycle = 'Требуется корректный цикл оплаты';
   }
-  
+
   if (!subscription.category || !Object.values(CATEGORIES).includes(subscription.category)) {
-    errors.category = 'Valid category is required';
+    errors.category = 'Требуется корректная категория';
   }
-  
+
   if (!subscription.nextPaymentDate) {
-    errors.nextPaymentDate = 'Next payment date is required';
+    errors.nextPaymentDate = 'Требуется дата следующего платежа';
   }
   
   return {
@@ -128,7 +128,7 @@ export const getSampleSubscriptions = () => [
   {
     id: generateId(),
     name: 'Netflix',
-    description: 'Streaming service',
+    description: 'Стриминговый сервис',
     amount: 15.99,
     currency: 'USD',
     billingCycle: 'monthly',
@@ -142,7 +142,7 @@ export const getSampleSubscriptions = () => [
   {
     id: generateId(),
     name: 'Spotify Premium',
-    description: 'Music streaming',
+    description: 'Музыкальный стриминг',
     amount: 9.99,
     currency: 'USD',
     billingCycle: 'monthly',
@@ -156,7 +156,7 @@ export const getSampleSubscriptions = () => [
   {
     id: generateId(),
     name: 'Adobe Creative Suite',
-    description: 'Design software',
+    description: 'Пакет для дизайна',
     amount: 52.99,
     currency: 'USD',
     billingCycle: 'monthly',
@@ -169,8 +169,8 @@ export const getSampleSubscriptions = () => [
   },
   {
     id: generateId(),
-    name: 'Gym Membership',
-    description: 'Local fitness center',
+    name: 'Абонемент в спортзал',
+    description: 'Местный фитнес-центр',
     amount: 35.00,
     currency: 'USD',
     billingCycle: 'monthly',


### PR DESCRIPTION
## Summary
- translate navigation, modals and pages to Russian
- localize validation messages and currency formatting
- update auth form and filters for Russian language

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, unused vars, no-undef)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c8b0247c832ca6eb9c4b6c277208