### PR TITLE
Fix edit modal data binding on dashboard

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -274,7 +274,7 @@ const Dashboard = () => {
         <AddSubscriptionModal
           isOpen={isModalOpen}
           onClose={handleModalClose}
-          editingSubscription={editingSubscription}
+          editSubscription={editingSubscription}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- ensure the dashboard passes the correct `editSubscription` prop to the shared subscription modal so edit forms are pre-filled

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c96325244c832cac82248583b698be