### PR TITLE
Fix Russian translation for other category label

### DIFF
--- a/src/translations/ru.js
+++ b/src/translations/ru.js
@@ -78,7 +78,7 @@ export default {
     education: 'Образование',
     news: 'Новости и медиа',
     productivity: 'Продуктивность',
-    other: 'Проче��'
+    other: 'Прочее'
   },
   
   billingCycles: {


### PR DESCRIPTION
## Summary
- correct the Russian translation for the "other" category to remove stray characters in the label

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c969635ec0832c863d1b544a3124be