### PR TITLE
Fix lint errors

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -14,7 +14,7 @@ class ErrorBoundary extends React.Component {
     };
   }
 
-  static getDerivedStateFromError(_) {
+  static getDerivedStateFromError() {
     // Update state so the next render will show the fallback UI
     return { hasError: true };
   }

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useUnifiedAuth } from './auth/UnifiedAuthProvider.jsx';
+import { useUnifiedAuth } from './auth/UnifiedAuthContext.js';
 import Button from './ui/Button.jsx';
 import HeroSection from './landing/HeroSection.jsx';
 import FeaturesSection from './landing/FeaturesSection.jsx';

--- a/src/components/auth/ProtectedRoute.jsx
+++ b/src/components/auth/ProtectedRoute.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
-import { useUnifiedAuth } from './UnifiedAuthProvider.jsx';
+import { useUnifiedAuth } from './UnifiedAuthContext.js';
 import Loading from '../ui/Loading.jsx';
 
 const ProtectedRoute = ({ children }) => {
-  const { user, loading, isAuthenticated } = useUnifiedAuth();
+  const { loading, isAuthenticated } = useUnifiedAuth();
   const location = useLocation();
 
   // Show loading spinner while checking authentication

--- a/src/components/auth/UnifiedAuthContext.js
+++ b/src/components/auth/UnifiedAuthContext.js
@@ -1,0 +1,29 @@
+import { createContext, useContext } from 'react';
+
+const defaultAuthContext = {
+  user: null,
+  profile: null,
+  session: null,
+  loading: true,
+  error: null,
+  isAuthenticated: false,
+  signIn: () => {},
+  signUp: () => {},
+  signOut: () => {},
+  resetPassword: () => {},
+  getDisplayName: () => 'User',
+};
+
+export const UnifiedAuthContext = createContext(defaultAuthContext);
+
+export const useUnifiedAuth = () => {
+  const context = useContext(UnifiedAuthContext);
+
+  if (!context) {
+    throw new Error('useUnifiedAuth must be used within a UnifiedAuthProvider');
+  }
+
+  return context;
+};
+
+export default UnifiedAuthContext;

--- a/src/components/auth/UnifiedAuthProvider.jsx
+++ b/src/components/auth/UnifiedAuthProvider.jsx
@@ -1,37 +1,13 @@
-import React, { createContext, useContext } from 'react';
+import React from 'react';
 import useUnifiedStore from '../../store/unified-store.js';
 import { supabase } from '../../lib/supabase.js';
-
-// Create authentication context that uses unified store
-const UnifiedAuthContext = createContext({
-  user: null,
-  profile: null,
-  session: null,
-  loading: true,
-  error: null,
-  isAuthenticated: false,
-  signIn: () => {},
-  signUp: () => {},
-  signOut: () => {},
-  resetPassword: () => {},
-  getDisplayName: () => 'User',
-});
-
-// Custom hook to use unified authentication context
-export const useUnifiedAuth = () => {
-  const context = useContext(UnifiedAuthContext);
-  if (!context) {
-    throw new Error('useUnifiedAuth must be used within a UnifiedAuthProvider');
-  }
-  return context;
-};
+import UnifiedAuthContext from './UnifiedAuthContext.js';
 
 // Unified AuthProvider component
 export const UnifiedAuthProvider = ({ children }) => {
   // Get auth state from unified store
   const auth = useUnifiedStore(state => state.auth);
   const getDisplayName = useUnifiedStore(state => state.getDisplayName);
-  const resetToUnauthenticated = useUnifiedStore(state => state.resetToUnauthenticated);
 
   // Authentication methods that work with unified store
   const signIn = async (email, password) => {

--- a/src/contexts/LanguageContext.jsx
+++ b/src/contexts/LanguageContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useMemo, useCallback } from 'react';
+import React, { createContext, useState, useEffect, useMemo, useCallback } from 'react';
 import { translations, SUPPORTED_LANGUAGES } from '@/translations';
 
 // Create the Language Context
@@ -109,15 +109,6 @@ export const LanguageProvider = ({ children }) => {
       {children}
     </LanguageContext.Provider>
   );
-};
-
-// useTranslation hook to access the translation context
-export const useTranslation = () => {
-  const context = useContext(LanguageContext);
-  if (!context) {
-    throw new Error('useTranslation must be used within a LanguageProvider');
-  }
-  return context;
 };
 
 export default LanguageContext;

--- a/src/hooks/useTranslation.js
+++ b/src/hooks/useTranslation.js
@@ -1,8 +1,15 @@
-import { useTranslation as useTranslationContext } from '@/contexts/LanguageContext';
+import { useContext } from 'react';
+import LanguageContext from '@/contexts/LanguageContext.jsx';
 
 // Enhanced useTranslation hook with additional utility functions
 export const useTranslation = () => {
-  const { currentLanguage, setLanguage, t, isLoading } = useTranslationContext();
+  const context = useContext(LanguageContext);
+
+  if (!context) {
+    throw new Error('useTranslation must be used within a LanguageProvider');
+  }
+
+  const { currentLanguage, setLanguage, t, isLoading } = context;
   
   // Enhanced translation function with array key support
   const translate = (key, values = {}) => {
@@ -33,7 +40,7 @@ export const useTranslation = () => {
         currency: currency
       }).format(amount);
     } catch (error) {
-      // Fallback to simple formatting
+      console.error('Failed to format currency', error);
       return `${amount} ${currency}`;
     }
   };
@@ -48,7 +55,7 @@ export const useTranslation = () => {
         ...options
       }).format(new Date(date));
     } catch (error) {
-      // Fallback to simple formatting
+      console.error('Failed to format date', error);
       return new Date(date).toLocaleDateString();
     }
   };

--- a/src/pages/AuthPage.jsx
+++ b/src/pages/AuthPage.jsx
@@ -1,12 +1,10 @@
 import React, { useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useUnifiedAuth } from '../components/auth/UnifiedAuthProvider.jsx';
+import { useUnifiedAuth } from '../components/auth/UnifiedAuthContext.js';
 import AuthForm from '../components/AuthForm.jsx';
 import Loading from '@/components/ui/Loading';
-import { useTranslation } from '@/hooks/useTranslation';
 
 const AuthPage = () => {
-  const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
   const { user, loading } = useUnifiedAuth();

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -3,7 +3,7 @@ import { Settings as SettingsIcon, Download, Trash2, User, LogOut, Globe } from 
 import { useShallow } from 'zustand/react/shallow';
 import useUnifiedStore from '@/store/unified-store';
 import { Card, Button } from '@/components/ui';
-import { useUnifiedAuth } from '@/components/auth/UnifiedAuthProvider';
+import { useUnifiedAuth } from '@/components/auth/UnifiedAuthContext.js';
 import LanguageSwitcher from '@/components/LanguageSwitcher.jsx';
 import { useTranslation } from '@/hooks/useTranslation';
 

--- a/src/pages/Subscriptions.jsx
+++ b/src/pages/Subscriptions.jsx
@@ -13,7 +13,7 @@ import useUnifiedStore from '@/store/unified-store';
 import { Button, Input, Select, Card } from '@/components/ui';
 import SubscriptionCard from '../components/SubscriptionCard.jsx';
 import AddSubscriptionModal from '../components/AddSubscriptionModal.jsx';
-import { getCategoryLabel, getCategoryOptionsWithAll, getStatusOptions, getSortOptions } from '@/types';
+import { getCategoryOptionsWithAll, getStatusOptions, getSortOptions } from '@/types';
 
 const Subscriptions = () => {
   // Optimized unified store selectors with shallow comparison

--- a/src/utils/fieldMapping.js
+++ b/src/utils/fieldMapping.js
@@ -80,7 +80,7 @@ export const subscriptionToDatabase = (subscription) => {
   
   // Remove undefined values
   return Object.fromEntries(
-    Object.entries(mapped).filter(([_, value]) => value !== undefined)
+    Object.entries(mapped).filter(([, value]) => value !== undefined)
   );
 };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'path'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -8,7 +12,7 @@ export default defineConfig({
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
     alias: {
-      '@': path.resolve(__dirname, './src')
+      '@': resolve(__dirname, './src')
     }
   },
   build: {


### PR DESCRIPTION
## Summary
- split the unified auth hook into its own context module to satisfy Fast Refresh linting
- rework the language context consumer hook and clean up unused variables across pages and utilities
- define __dirname for Vite ESM config and address remaining ESLint warnings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c96a41d938832ca1ed7798ccd9cbd8